### PR TITLE
Use Urls with domain when finding duplicates, ignore query string

### DIFF
--- a/VirtualNodes/VirtualNodesContentFinder.cs
+++ b/VirtualNodes/VirtualNodesContentFinder.cs
@@ -17,7 +17,11 @@ public class VirtualNodesContentFinder : IContentFinder
         var cachedVirtualNodeUrls = ApplicationContext.Current.ApplicationCache.RuntimeCache.GetCacheItem<Dictionary<string, int>>("cachedVirtualNodes");
 
         //Get the request path
-        string path = contentRequest.Uri.AbsolutePath;
+        string path = contentRequest.Uri.AbsoluteUri;
+        if (path.IndexOf('?') != -1)
+        {
+            path = path.Substring(0, path.IndexOf('?'));
+        }
 
         //If found in the cached dictionary, get the node id from there
         if (cachedVirtualNodeUrls != null && cachedVirtualNodeUrls.ContainsKey(path)) {
@@ -29,11 +33,10 @@ public class VirtualNodesContentFinder : IContentFinder
         //If not found on the cached dictionary, traverse nodes and find the node that corresponds to the URL
         var rootNodes = contentRequest.RoutingContext.UmbracoContext.ContentCache.GetAtRoot();
         IPublishedContent item = null;
-            item = rootNodes
-                    .DescendantsOrSelf<IPublishedContent>()
-                    .Where(x => x.Url == (path + "/") || x.Url == path)
-                    .FirstOrDefault();
-
+        item = rootNodes
+                .DescendantsOrSelf<IPublishedContent>()
+                .Where(x => x.UrlWithDomain() == (path + "/") || x.UrlWithDomain() == path)
+                .FirstOrDefault();
         //If item is found, return it after adding it to the cache so we don't have to go through the same process again.
         if (cachedVirtualNodeUrls == null) { cachedVirtualNodeUrls = new Dictionary<string, int>(); }
 


### PR DESCRIPTION
Hi,

We're using VirtualNodes for a project where we need to hide language nodes for pages with the same path but different domains (We have a root node for each domain), e.g. http;//www.domain1.com/nl/page1 and http;//www.domain2.com/nl/page1

I've made the changes in this pull request to make it work without complaining about collisions in the "Link to document" section in the properties tab on content nodes.

I hope you'll find these changes useful.

Best regards,
Tom Andresen